### PR TITLE
Fix opal showcase scroller

### DIFF
--- a/components/ExhibitPages.tsx
+++ b/components/ExhibitPages.tsx
@@ -133,13 +133,26 @@ export const ExhibitPages = () => {
     setScrollableWidth(-value)
   }, [])
 
+  const timeout = useRef<any>(null)
+
   useEffect(() => {
     updateScrollableWidth()
+
+    const delay = 1000
+
+    const loop = () => {
+      updateScrollableWidth()
+      timeout.current = setTimeout(loop, delay)
+    }
+
+    timeout.current = setTimeout(loop)
 
     const stop = resize(() => updateScrollableWidth())
 
     return () => {
       stop()
+
+      clearTimeout(timeout.current)
     }
   }, [updateScrollableWidth])
 


### PR DESCRIPTION
The dimensions take a few hundred milliseconds before it's ready, so just update the dimensions every second. ez.